### PR TITLE
Miniconda + Komodo-edit + Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Example Uses
 
 ``make virtualbox``
 
-The virtualbox OVA unlink the other variants will include a graphical environment ([Xubuntu](http://xubuntu.org/)) tailored for development (auto logins to the ``ubuntu`` user, configured with tools such as [Atom](https://atom.io/)).
+The virtualbox OVA unlink the other variants will include a graphical environment ([Xubuntu](http://xubuntu.org/)) tailored for development (auto logins to the ``ubuntu`` user, configured with tools such as [Komodo](http://komodoide.com/komodo-edit/)).
 
  * Build a modified variant of the recipes with a Dockerfile directly
      (skipping packer). Skipping packer makes it easier to iterate on and applicable

--- a/roles/galaxyprojectdotorg.devbox/tasks/main.yml
+++ b/roles/galaxyprojectdotorg.devbox/tasks/main.yml
@@ -103,7 +103,7 @@
   template: src=Desktop/{{ item }}.desktop.j2 dest={{ dev_user_home }}/Desktop/{{ item }}.desktop mode=a+x owner={{ dev_user_name }} group={{ dev_user_group }}
   when: galaxy_devbox_include_x
   with_items:
-    - atom
+    - komodo-edit
     - exo-terminal-emulator
     - exo-web-browser
     - galaxyproject
@@ -198,7 +198,3 @@
 - name: "Add the keyboard layout switcher to the panel."
   template: src=xfce4-panel.xml.j2 dest={{ dev_user_home }}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
   when: galaxy_devbox_include_x
-
-- name: "Workaround for atom"
-  become: True
-  shell: "/opt/atom/atom &"

--- a/roles/galaxyprojectdotorg.devbox/tasks/main.yml
+++ b/roles/galaxyprojectdotorg.devbox/tasks/main.yml
@@ -33,7 +33,7 @@
     - npm
 
 # Setup atom (https://atom.io/) ppa and install.
-- name: Add custom Galaxy PPA (used for nginx package)
+- name: Add custom Galaxy PPA (used for atom package)
   apt_repository: repo="ppa:webupd8team/atom" update_cache=yes
   when: galaxy_devbox_include_x
 

--- a/roles/galaxyprojectdotorg.devbox/tasks/main.yml
+++ b/roles/galaxyprojectdotorg.devbox/tasks/main.yml
@@ -32,6 +32,11 @@
     - nodejs
     - npm
 
+# Setup atom (https://atom.io/) ppa and install.
+- name: Add custom Galaxy PPA (used for nginx package)
+  apt_repository: repo="ppa:webupd8team/atom" update_cache=yes
+  when: galaxy_devbox_include_x
+
 # Setup komodo-edit ppa and install.
 - name: Add custom PPA (used for komodo-edit package)
   apt_repository: repo="ppa:mystic-mirage/komodo-edit" update_cache=yes
@@ -40,6 +45,7 @@
 - name: Install the debs (X11 environment)
   apt: name={{ item }} state=latest update_cache=yes
   with_items:
+    - atom
     - komodo-edit
     - xfce4-xkb-plugin
     - gedit
@@ -103,6 +109,7 @@
   template: src=Desktop/{{ item }}.desktop.j2 dest={{ dev_user_home }}/Desktop/{{ item }}.desktop mode=a+x owner={{ dev_user_name }} group={{ dev_user_group }}
   when: galaxy_devbox_include_x
   with_items:
+    - atom
     - komodo-edit
     - exo-terminal-emulator
     - exo-web-browser
@@ -192,9 +199,14 @@
   become: True
   shell: "/usr/sbin/update-motd"
 
+- name: Ensure existence of .config directory
+  file: path={{ dev_user_home }}/.config/ state=directory owner={{ dev_user_name }} group={{ dev_user_group }}
+
 - name: Ensure existence of target directory for next step.
-  file: path={{ dev_user_home }}/.config/xfce4/xfconf/xfce-perchannel-xml state=directory
+  file: path={{ dev_user_home }}/.config/xfce4/xfconf/xfce-perchannel-xml state=directory owner={{ dev_user_name }} group={{ dev_user_group }}
 
 - name: "Add the keyboard layout switcher to the panel."
   template: src=xfce4-panel.xml.j2 dest={{ dev_user_home }}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+  become: True
+  become_user: "{{ dev_user_name }}"
   when: galaxy_devbox_include_x

--- a/roles/galaxyprojectdotorg.devbox/tasks/main.yml
+++ b/roles/galaxyprojectdotorg.devbox/tasks/main.yml
@@ -193,7 +193,6 @@
 
 - name: "Add the local environment settings."
   template: src=planemo-machine.sh.j2 dest={{ dev_user_home }}/.planemo-machine
-  when: galaxy_devbox_include_x
 
 - name: "Update login notifications."
   become: True
@@ -204,6 +203,14 @@
 
 - name: Ensure existence of target directory for next step.
   file: path={{ dev_user_home }}/.config/xfce4/xfconf/xfce-perchannel-xml state=directory owner={{ dev_user_name }} group={{ dev_user_group }}
+
+- name: Download miniconda
+  become: True
+  become_user: "{{ dev_user_name }}"
+  shell: "cd {{ dev_user_home }} && curl https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -L -o miniconda.sh && bash miniconda.sh -b"
+
+- name: Add miniconda bin to PATH.
+  lineinfile: "dest={{ dev_user_shellrc }} line='export PATH=$PATH:{{ dev_user_home }}/miniconda2/bin/'"
 
 - name: "Add the keyboard layout switcher to the panel."
   template: src=xfce4-panel.xml.j2 dest={{ dev_user_home }}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml

--- a/roles/galaxyprojectdotorg.devbox/templates/Desktop/atom.desktop.j2
+++ b/roles/galaxyprojectdotorg.devbox/templates/Desktop/atom.desktop.j2
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Atom
+Comment=A hackable text editor for the 21st century
+Exec=/opt/atom/atom %F
+Icon=atom
+Type=Application
+StartupNotify=true
+Categories=TextEditor;Development;Utility;
+MimeType=text/plain;
+X-Desktop-File-Install-Version=0.22

--- a/roles/galaxyprojectdotorg.devbox/templates/Desktop/komodo-edit.desktop.j2
+++ b/roles/galaxyprojectdotorg.devbox/templates/Desktop/komodo-edit.desktop.j2
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=Atom
-Comment=A hackable text editor for the 21st century
-Exec=/opt/atom/atom %F
-Icon=atom
+Name=Komodo Edit
+Comment=Free multi-platform editor that makes it easy to write quality code.
+Exec=komodo-edit %F
+Icon=komodo-edit
 Type=Application
 StartupNotify=true
 Categories=TextEditor;Development;Utility;


### PR DESCRIPTION
This builds on #81 and covers the following:
- Adds Desktop link for Komodo-edit 
- Fixes Atom editor.
- Install miniconda into `ubuntu`'s `HOME` and adds it to its `.bashrc`.
