### PR TITLE
Adding openssl dependencies to setup before running ansible

### DIFF
--- a/scripts/setup_ansible.sh
+++ b/scripts/setup_ansible.sh
@@ -6,6 +6,7 @@ if [ $? -ne 0 ];
 then
     sudo apt-get update -y
     sudo apt-get install -y software-properties-common
+    sudo apt-get install -y build-essential libssl-dev libffi-dev
     sudo apt-get install -y python-dev
     sudo apt-get install -y python-pip
     sudo pip install setuptools --upgrade


### PR DESCRIPTION
Without fix GCE build gets

```
 googlecompute: x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c build/temp.linux-x86_64-2.7/_openssl.c -o build/temp.linux-x86_64-2.7/build/temp.linux-x86_64-2.7/_openssl.o
    googlecompute: build/temp.linux-x86_64-2.7/_openssl.c:429:30: fatal error: openssl/opensslv.h: No such file or directory
    googlecompute: compilation terminated.
    googlecompute: error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    googlecompute:
    googlecompute: ----------------------------------------


```
