### PR TITLE
Virtualbox: use ubuntu 16.04.2 + fix vmdk name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,12 @@ docker-via-packer: packer
 
 _virtualbox-ova:
 	mv output-virtualbox-iso/*ovf $(IMAGE_NAME).ovf
-	mv output-virtualbox-iso/*-disk1.vmdk $(IMAGE_NAME)-disk1.vmdk
-	sed -i -e 's/<File.*/<File ovf:href="planemo-machine-disk1.vmdk" ovf:id="file1"\/>/g' $(IMAGE_NAME).ovf
+	mv output-virtualbox-iso/*-disk001.vmdk $(IMAGE_NAME)-disk001.vmdk
+	sed -i -e 's/<File.*/<File ovf:href="planemo-machine-disk001.vmdk" ovf:id="file1"\/>/g' $(IMAGE_NAME).ovf
 	sed -i -e 's/<Clipboard.*/<Clipboard mode="Bidirectional"\/>/g' $(IMAGE_NAME).ovf
 	sed -i -e "s:packer-virtualbox-iso:$(IMAGE_NAME):g" $(IMAGE_NAME).ovf
 	tar cvf $(IMAGE_NAME).ova $(IMAGE_NAME).ovf
-	tar uvf $(IMAGE_NAME).ova $(IMAGE_NAME)-disk1.vmdk
+	tar uvf $(IMAGE_NAME).ova $(IMAGE_NAME)-disk001.vmdk
 
 # Convert the VirtualBox Image into a Qemu Image for use in OpenStack
 _create_qemu_image: packer

--- a/packer.json
+++ b/packer.json
@@ -30,7 +30,7 @@
   "builders": [
     {
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso", 
-      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso", 
+      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso", 
       "ssh_port": 22, 
       "ssh_username": "{{ user `username` }}", 
       "iso_checksum_type": "sha256", 
@@ -83,7 +83,7 @@
       ], 
       "guest_os_type": "Ubuntu_64", 
       "name": "virtualbox-iso", 
-      "iso_checksum": "b8b172cbdf04f5ff8adc8c2c1b4007ccf66f00fc6a324a6da6eba67de71746f6", 
+      "iso_checksum": "737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535", 
       "boot_wait": "10s", 
       "http_directory": "http", 
       "headless": true, 
@@ -93,7 +93,7 @@
     }, 
     {
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso", 
-      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso", 
+      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso", 
       "ssh_port": 22, 
       "ssh_username": "{{ user `username` }}", 
       "iso_checksum_type": "sha256", 
@@ -146,7 +146,7 @@
       ], 
       "guest_os_type": "Ubuntu_64", 
       "name": "virtualbox-iso-vagrant", 
-      "iso_checksum": "b8b172cbdf04f5ff8adc8c2c1b4007ccf66f00fc6a324a6da6eba67de71746f6", 
+      "iso_checksum": "737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535", 
       "boot_wait": "10s", 
       "http_directory": "http", 
       "headless": true, 

--- a/packer.yaml
+++ b/packer.yaml
@@ -54,9 +54,9 @@ builders:
   guest_os_type: Ubuntu_64
   headless: true
   http_directory: http
-  iso_checksum: b8b172cbdf04f5ff8adc8c2c1b4007ccf66f00fc6a324a6da6eba67de71746f6
+  iso_checksum: 737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535
   iso_checksum_type: sha256
-  iso_url: http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso
+  iso_url: http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso
   shutdown_command: echo 'shutdown -P now' > shutdown.sh; echo '{{ user `username` }}'|sudo -S sh 'shutdown.sh'
   ssh_password: '{{ user `password` }}'
   ssh_port: 22


### PR DESCRIPTION
Hi,
I wanted to generate a virtualbox VM with newer versions of galaxy/planemo/conda, and I had to make this little changes to make the `make virtualbox` work.